### PR TITLE
installing sqlite3, but only when needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .env
+bin

--- a/tests/setup.sh
+++ b/tests/setup.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 
+# Check if sqlite3 is installed
+if ! command -v sqlite3 &> /dev/null; then
+    echo "sqlite3 could not be found, installing now..."
+        sudo apt update
+        sudo apt install -y sqlite3
+fi
+
 sqlite3 db/db.sqlite < db/reset.sql


### PR DESCRIPTION
I once removed `sudo apt install sqlite3` as it was running with each test and slowing things down horribly.

Github's (giant) test runner image has it anyway.

But we're running into scenarios where we want to assert the presence of sqlite3 (e.g. local development with [act](https://github.com/nektos/act).

Great news is that the new approach to testing with `./test.sh 1a` will just install sqlite3 once, and only if needed.

So we get the best of all worlds.